### PR TITLE
Redirect user to panel after login with credentials

### DIFF
--- a/app/lib/ui/login-form.tsx
+++ b/app/lib/ui/login-form.tsx
@@ -12,7 +12,8 @@ export default function LoginForm() {
 
     if (!isPending && session?.success === true) {
         setTimeout(() => {
-            redirect(session.redirectTo);
+            //redirect(session.redirectTo);
+            location.href = session.redirectTo;
         }, 500);
     }
 


### PR DESCRIPTION
Redirect user to panel after login with credentials, because some image cache issue was preventing user avatar loading.